### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ PC control
 Android control  
 ![MiniQ](https://github.com/billhsu/MiniQ/raw/master/doc/android.png)
 
-##Author
+## Author
 **Shipeng Xu**
 
 + http://BillHsu.me


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
